### PR TITLE
fix missing image when no image for item

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,9 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image ? item.image : process.env.PUBLIC_URL + "/placeholder.png"}
+        src={
+          item.image ? item.image : process.env.PUBLIC_URL + "/placeholder.png"
+        }
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image ? item.image : process.env.PUBLIC_URL + "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
This change will test if there is an image for the item, if not, it will place the `placeholder.img` instead
